### PR TITLE
Fix/editable on drop

### DIFF
--- a/gadget.js
+++ b/gadget.js
@@ -24,14 +24,6 @@ var Gadget = function() {
     ]
   }});*/
 
-  // Asset URL template override
-  player.assetUrlTemplate = player.assetUrlTemplate ||
-    'http://localhost:3000/api/assets/<%= id %>';
-  // Update based on env
-  player.on('environmentChanged', function(data){
-    player.assetUrlTemplate = data && data.assetUrlTemplate;
-  }.bind(this));
-
   player.on('editableChanged', this.toggleEdit.bind(this));
   player.on('attributesChanged', this.attributesChanged.bind(this));
 

--- a/gadget.js
+++ b/gadget.js
@@ -32,18 +32,8 @@ var Gadget = function() {
     player.assetUrlTemplate = data && data.assetUrlTemplate;
   }.bind(this));
 
-  // Doesn't seem to work:
-  //player.on('editableChanged', this.toggleEdit.bind(this));
+  player.on('editableChanged', this.toggleEdit.bind(this));
   player.on('attributesChanged', this.attributesChanged.bind(this));
-
-  // Handle edit toggling
-  window.addEventListener('message', function(e){
-    var message = e.data;
-
-    if(message.event=="setEditable") {
-      self.toggleEdit(message.data);
-    }
-  });
 
   player.startListening();
 };


### PR DESCRIPTION
Not sure why `editableChanged` wasn't working for you but it works now. Also the `assetUrlTemplate` deal is much better now, don't have to do anything special when you use player-api.
